### PR TITLE
Websocket changes to fallback to wss when used inside a docker container

### DIFF
--- a/src/lib/pricer/pricedb/pricedb-socket-manager.ts
+++ b/src/lib/pricer/pricedb/pricedb-socket-manager.ts
@@ -130,7 +130,7 @@ export default class PriceDbSocketManager extends EventEmitter {
         this.reconnectTimer = setTimeout(() => {
             this.reconnectTimer = null;
             if (!this.shouldReconnect) return;
-                this.connect(preferTLS, true);
+            this.connect(preferTLS, true);
         }, delay);
     }
 

--- a/src/lib/pricer/pricedb/pricedb-socket-manager.ts
+++ b/src/lib/pricer/pricedb/pricedb-socket-manager.ts
@@ -6,50 +6,83 @@ export default class PriceDbSocketManager extends EventEmitter {
     private socket: Socket | null = null;
 
     private reconnectAttempts = 0;
-
-    private maxReconnectAttempts = 5;
-
+    private maxReconnectAttempts = 3;
     private reconnectDelay = 1000;
+    private maxReconnectDelay = 30000;
 
+    private shouldReconnect = true;
     public isConnecting = false;
 
-    constructor(private url: string = 'ws://ws.pricedb.io/') {
+    private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+    constructor(
+        private readonly url: string = 'ws://ws.pricedb.io/',
+        private readonly urlTLS: string = 'wss://ws.pricedb.io/'
+    ) {
         super();
     }
 
-    connect(): void {
-        if (this.socket && this.socket.connected) {
-            log.debug('PriceDB socket already connected');
+    connect(preferTLS = false, force = false): void {
+        if (this.socket && this.socket.connected && !force) {
+            log.debug(`PriceDB socket already connected.`);
             return;
         }
 
-        this.isConnecting = true;
-        log.debug('Connecting to PriceDB WebSocket...');
+        if (!force && this.isConnecting) {
+            log.debug('Already trying to connect to PriceDB...');
+            return;
+        }
 
-        this.socket = io(this.url, {
+        if (this.reconnectTimer) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = null;
+        }
+
+        if (this.socket) {
+            try {
+                this.socket.removeAllListeners();
+                this.socket.disconnect();
+            } catch (e) {
+                log.warn('Error while cleaning previous socket:', e);
+            }
+            this.socket = null;
+        }
+
+        this.isConnecting = true;
+        const endpoint = preferTLS ? this.urlTLS : this.url;
+        log.debug(`Connecting to PriceDB WebSocket ${preferTLS ? '[TLS]' : ''} ${endpoint}...`);
+
+        this.socket = io(endpoint, {
             transports: ['websocket'],
-            timeout: 10000,
-            reconnection: false // We'll handle reconnection manually
+            timeout: 10_000,
+            reconnection: false,
+            autoConnect: true
         });
 
         this.socket.on('connect', () => {
-            log.debug('✅ Connected to PriceDB WebSocket');
+            log.debug(`✅ Connected to PriceDB ${preferTLS ? '[TLS]' : ''} ${endpoint}`);
             this.isConnecting = false;
             this.reconnectAttempts = 0;
             this.emit('connected');
         });
 
         this.socket.on('disconnect', reason => {
-            log.debug(`Disconnected from PriceDB WebSocket: ${reason}`);
+            log.debug(`Disconnected from PriceDB ${preferTLS ? '[TLS]' : ''} WebSocket: ${reason}`);
             this.isConnecting = false;
             this.emit('disconnected', reason);
-            this.handleReconnect();
+
+            if (this.shouldReconnect) {
+                this.scheduleReconnect(preferTLS);
+            }
         });
 
         this.socket.on('connect_error', error => {
-            log.warn('PriceDB WebSocket connection error:', error);
+            log.warn(`PriceDB WebSocket ${preferTLS ? '[TLS]' : ''} connection error:`, error);
             this.isConnecting = false;
-            this.handleReconnect();
+
+            if (this.shouldReconnect) {
+                this.scheduleReconnect(preferTLS);
+            }
         });
 
         this.socket.on('price', data => {
@@ -58,35 +91,67 @@ export default class PriceDbSocketManager extends EventEmitter {
         });
     }
 
-    private handleReconnect(): void {
-        if (this.reconnectAttempts >= this.maxReconnectAttempts) {
-            log.error('Max reconnection attempts reached for PriceDB WebSocket');
-            return;
+    private scheduleReconnect(preferTLS: boolean): void {
+        if (!this.shouldReconnect) return;
+        if (this.reconnectTimer) return;
+
+        this.reconnectAttempts += 1;
+
+        if (this.reconnectAttempts > this.maxReconnectAttempts) {
+            if (!preferTLS) {
+                log.warn('Max non-TLS reconnect attempts reached, falling back to TLS endpoint.');
+                this.reconnectAttempts = 0;
+                this.reconnectTimer = setTimeout(() => {
+                    this.reconnectTimer = null;
+                    if (!this.shouldReconnect) return;
+                    this.connect(true, true);
+                }, 500);
+                return;
+            } else {
+                log.error('Max reconnect attempts reached for PriceDB (both protocols tried).');
+                this.reconnectAttempts = 0;
+                return;
+            }
         }
 
-        this.reconnectAttempts++;
-        const delay = this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1);
+        let delay = this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1);
+        if (delay > this.maxReconnectDelay) delay = this.maxReconnectDelay;
 
         log.debug(
-            `Attempting to reconnect to PriceDB WebSocket in ${delay}ms (attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts})`
+            `Attempting to reconnect to PriceDB ${preferTLS ? '[TLS]' : ''} in ${delay}ms (attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts})`
         );
 
-        setTimeout(() => {
-            this.connect();
+        this.reconnectTimer = setTimeout(() => {
+            this.reconnectTimer = null;
+            if (!this.shouldReconnect) return;
+            this.connect(preferTLS, true);
         }, delay);
     }
 
     disconnect(): void {
-        if (this.socket) {
-            this.socket.disconnect();
-            this.socket = null;
-        }
+        this.shouldReconnect = false;
         this.isConnecting = false;
         this.reconnectAttempts = 0;
+
+        if (this.reconnectTimer) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = null;
+        }
+
+        if (this.socket) {
+            try {
+                this.socket.removeAllListeners();
+                this.socket.disconnect();
+            } catch (e) {
+                log.warn('Error while disconnecting socket:', e);
+            }
+            this.socket = null;
+        }
     }
 
     init(): void {
-        this.connect();
+        this.shouldReconnect = true;
+        this.connect(false);
     }
 
     shutdown(): void {


### PR DESCRIPTION
Changes in `pricedb-socket-manager.ts`:
- Reduced the number of connection attempts from 5 to 3.
- Updated the WebSocket connection logic: the bot now tries non-TLS first for 3 attempts, and if that fails, it falls back to TLS.