### PR TITLE
fix: refreshing stale cache for listings, bonus fix for !addbulk/!updatebulk

### DIFF
--- a/src/classes/Commands/sub-classes/PricelistManager.ts
+++ b/src/classes/Commands/sub-classes/PricelistManager.ts
@@ -469,6 +469,7 @@ export default class PricelistManagerCommands {
                         });
                 }
             } catch (err) {
+                PricelistManagerCommands.isBulkOperation = false;
                 return this.bot.sendMessage(
                     steamID,
                     `❌ Bulk add operation aborted: Failed to obtain pricelist from pricer: ${(err as Error)?.message}`
@@ -1516,6 +1517,7 @@ export default class PricelistManagerCommands {
                         });
                 }
             } catch (err) {
+                PricelistManagerCommands.isBulkOperation = false;
                 return this.bot.sendMessage(
                     steamID,
                     `❌ Bulk update operation aborted: Failed to obtain pricelist from pricer: ${


### PR DESCRIPTION
From testing and with frequent price updates, I noticed that the bot's cache which is used for listing updates can go stale and may contain multiple listing updates for the same item, be it buy or sell orders.  This caused it to compare new prices against outdated cached prices instead of the prices that were actually queued for update. This resulted in:

- Duplicate listing update attempts for the same price
- Unnecessary API calls to backpack.tf
- Price updates being detected as changes even when they matched the queued price

**Solution:**
- Track expected prices in a map (`expectedListingPrices`) for all listings pending updates
- Compare new prices against expected prices (if available) instead of stale cache
- Implement debounced cache refresh with automatic cleanup of synced prices
- Clear expected price tracking when listings are removed or updates complete

**Bonus Fix**
- Reset the bulk operation flag when the bot aborts the `!addbulk` / `!updatebulk` command due to some error, otherwise the command is frozen unless the bot is restarted