### PR TITLE
[codex] Disable items when custom pricing is unavailable

### DIFF
--- a/src/classes/IPricer.ts
+++ b/src/classes/IPricer.ts
@@ -60,6 +60,7 @@ export interface GetItemPriceResponse {
     currency?: string;
     source?: string;
     time?: number;
+    available?: boolean;
     buy?: Currencies;
     sell?: Currencies;
     message?: string;

--- a/src/classes/Pricelist.ts
+++ b/src/classes/Pricelist.ts
@@ -44,6 +44,7 @@ export interface EntryData {
     purchaseHistory?: PurchaseRecord[];
     partialPriceTime?: number | null;
     lastInStockTime?: number | null;
+    disabledByPricer?: boolean;
 }
 
 export class Entry implements EntryData {
@@ -82,6 +83,8 @@ export class Entry implements EntryData {
     partialPriceTime: number | null;
 
     lastInStockTime: number | null;
+
+    disabledByPricer: boolean;
 
     private constructor(entry: EntryData, name: string) {
         this.sku = entry.sku;
@@ -150,6 +153,7 @@ export class Entry implements EntryData {
         this.purchaseHistory = entry.purchaseHistory || [];
         this.partialPriceTime = entry.partialPriceTime ?? null;
         this.lastInStockTime = entry.lastInStockTime ?? null;
+        this.disabledByPricer = entry.disabledByPricer ?? false;
     }
 
     clone(): Entry {
@@ -271,7 +275,7 @@ export class Entry implements EntryData {
     }
 
     getJSON(): EntryData {
-        const obj = {
+        const obj: EntryData = {
             sku: this.sku,
             enabled: this.enabled,
             autoprice: this.autoprice,
@@ -289,6 +293,10 @@ export class Entry implements EntryData {
             partialPriceTime: this.partialPriceTime,
             lastInStockTime: this.lastInStockTime
         };
+
+        if (this.disabledByPricer) {
+            obj.disabledByPricer = true;
+        }
 
         if (this.id) {
             obj['id'] = this.id;
@@ -709,6 +717,9 @@ export default class Pricelist extends EventEmitter {
         }
 
         const entry = Entry.fromData(entryData, this.schema);
+        if (src === PricelistChangedSource.Command) {
+            entry.disabledByPricer = false;
+        }
 
         if (isBulk && pricerItems !== null && this.transformedPricelistForBulk === undefined) {
             this.transformedPricelistForBulk = Pricelist.transformPricesFromPricer(pricerItems);
@@ -1337,6 +1348,17 @@ export default class Pricelist extends EventEmitter {
         const dw = opt.discordWebhook.priceUpdate;
         const isDwEnabled = dw.enable && dw.url !== '';
 
+        if (data.available === false) {
+            if (match !== null && match.autoprice && match.enabled) {
+                match.enabled = false;
+                match.disabledByPricer = true;
+                log.warn(`Disabled ${data.sku}: ${data.message || 'price unavailable'}`);
+                this.priceChanged(match.sku, match);
+                this.emit('pricelist', this.prices);
+            }
+            return;
+        }
+
         let newPrices: BuyAndSell;
 
         try {
@@ -1361,6 +1383,13 @@ export default class Pricelist extends EventEmitter {
             }
 
             return;
+        }
+
+        const restorePricerDisabledEntry = match !== null && match.autoprice && match.disabledByPricer;
+        if (restorePricerDisabledEntry) {
+            match.enabled = true;
+            match.disabledByPricer = false;
+            log.info(`Re-enabled ${data.sku}: valid price received`);
         }
 
         if (data.sku === '5021;6' && this.globalKeyPrices !== undefined) {
@@ -1423,7 +1452,10 @@ export default class Pricelist extends EventEmitter {
             const sellChangesValue = Math.round(newSellValue - oldSellValue);
 
             if (buyChangesValue === 0 && sellChangesValue === 0) {
-                // Ignore
+                if (restorePricerDisabledEntry) {
+                    this.priceChanged(match.sku, match);
+                    this.emit('pricelist', this.prices);
+                }
                 return;
             }
 
@@ -1578,8 +1610,11 @@ export default class Pricelist extends EventEmitter {
                 }
             }
 
-            if (pricesChanged) {
+            if (pricesChanged || restorePricerDisabledEntry) {
                 this.priceChanged(match.sku, match);
+            }
+            if (restorePricerDisabledEntry) {
+                this.emit('pricelist', this.prices);
             }
 
             if (isDwEnabled) {

--- a/src/lib/pricer/custom/custom-pricer-api.ts
+++ b/src/lib/pricer/custom/custom-pricer-api.ts
@@ -18,6 +18,7 @@ export interface CustomPricesGetItemPriceResponse extends CustomPricesResponse {
     currency?: string;
     source?: string;
     time?: number;
+    available?: boolean;
     buy?: PricesCurrency;
     sell?: PricesCurrency;
     message?: string;

--- a/src/lib/pricer/custom/custom-pricer.ts
+++ b/src/lib/pricer/custom/custom-pricer.ts
@@ -41,6 +41,7 @@ export default class CustomPricer implements IPricer {
             currency: response.currency,
             source: response.source,
             time: response.time,
+            available: response.available,
             buy: response.buy ? new Currencies(response.buy) : null,
             sell: response.sell ? new Currencies(response.sell) : null,
             message: response.message

--- a/src/schemas/pricelist-json/pricelist-add.ts
+++ b/src/schemas/pricelist-json/pricelist-add.ts
@@ -109,6 +109,9 @@ export const addSchema: jsonschema.Schema = {
                     type: 'null'
                 }
             ]
+        },
+        disabledByPricer: {
+            type: 'boolean'
         }
     },
     additionalProperties: false,

--- a/src/schemas/pricelist-json/pricelist.ts
+++ b/src/schemas/pricelist-json/pricelist.ts
@@ -78,6 +78,9 @@ export const pricelistSchema: jsonschema.Schema = {
         lastInStockTime: {
             type: ['number', 'null']
         },
+        disabledByPricer: {
+            type: 'boolean'
+        },
         name: {
             type: 'string'
         }

--- a/src/schemas/pricelist-json/pricesDataObject.ts
+++ b/src/schemas/pricelist-json/pricesDataObject.ts
@@ -79,6 +79,9 @@ export const pricesDataObject: jsonschema.Schema = {
                     },
                     lastInStockTime: {
                         type: ['number', 'null']
+                    },
+                    disabledByPricer: {
+                        type: 'boolean'
                     }
                 },
                 required: ['sku', 'enabled', 'autoprice', 'max', 'min', 'intent'],


### PR DESCRIPTION
## What changed

- support an optional `available` flag on custom-pricer price events
- disable an enabled autopriced entry when the custom pricer sends `available: false`
- persist whether the pricer disabled the entry
- restore only pricer-disabled entries when a valid price event later arrives
- clear the automatic restore marker when an administrator updates the entry
- extend the strict pricelist schemas for the persisted marker

## Why

Custom pricers can intentionally return no price when market data is insufficient or a generated price fails safety validation. Previously, no update was emitted and tf2autobot continued trading indefinitely with the old local price.

This change gives custom pricers an explicit unavailable-price contract while preserving operator control:

- manually priced entries are never disabled
- already manually disabled entries are untouched
- repeated unavailable events are idempotent
- malformed recovery payloads cannot re-enable an entry
- same-value valid prices still restore an entry disabled by the pricer

Example unavailable event:

```json
{
  "sku": "300;6",
  "available": false,
  "message": "required pricing data is not ready"
}
```

## Validation

- `npm run build`
- targeted ESLint on all changed files: no errors
- targeted Prettier check: passed
- `jest --runTestsByPath src/classes/__tests__/Pricelist.ts --runInBand`: 2 passed
- full direct Jest run: 4 suites and 12 tests passed; the existing `CommandParser` suite fails because Jest cannot parse the ESM-only `dot-prop` dependency

The repository-wide lint hook also reports existing unrelated errors outside this change.
