### PR TITLE
Add SteamBot.info inventory provider

### DIFF
--- a/.example/options.json
+++ b/.example/options.json
@@ -472,6 +472,9 @@
         },
         "expressLoad": {
             "enable": false
+        },
+        "steamBotInfo": {
+            "enable": false
         }
     },
     "discordChat": {

--- a/src/classes/InventoryApis/InventoryApi.ts
+++ b/src/classes/InventoryApis/InventoryApi.ts
@@ -36,6 +36,11 @@ export default class InventoryApi {
         return {};
     }
 
+    // Providers may wrap Steam's inventory payload in their own response object.
+    protected normalizeResponse(data: unknown): unknown {
+        return data;
+    }
+
     // Adapted from node-steamcommunity
     public getUserInventoryContents(
         userID: SteamID | string,
@@ -64,6 +69,7 @@ export default class InventoryApi {
         }
 
         const headers = this.getHeaders();
+        const normalizeResponse = this.normalizeResponse.bind(this);
 
         let pos = 1;
         get([], []);
@@ -78,7 +84,7 @@ export default class InventoryApi {
                 headers: headers
             }).then(
                 response => {
-                    const result = response.data as GetUserInventoryContentsResult;
+                    const result = normalizeResponse(response.data) as GetUserInventoryContentsResult;
 
                     if (response.status === 403 && result === null) {
                         callback(new Error('This profile is private.'));

--- a/src/classes/InventoryApis/SteamBotInfo.ts
+++ b/src/classes/InventoryApis/SteamBotInfo.ts
@@ -15,7 +15,7 @@ export default class SteamBotInfo extends InventoryApi {
         const apiKey = encodeURIComponent(this.getApiKey());
         return [
             `https://api.steambot.info/v1/${apiKey}/inventory/${steamID}/${appID}/${contextID}`,
-            { count: 5000, language: 'en' }
+            { count: 2000, language: 'en' }
         ];
     }
 

--- a/src/classes/InventoryApis/SteamBotInfo.ts
+++ b/src/classes/InventoryApis/SteamBotInfo.ts
@@ -1,0 +1,29 @@
+import { UnknownDictionaryKnownValues } from 'src/types/common';
+import Bot from '../Bot';
+import InventoryApi from './InventoryApi';
+
+export default class SteamBotInfo extends InventoryApi {
+    constructor(bot: Bot) {
+        super(bot, 'steamBotInfo');
+    }
+
+    protected getURLAndParams(
+        steamID: string,
+        appID: number,
+        contextID: string
+    ): [string, UnknownDictionaryKnownValues] {
+        const apiKey = encodeURIComponent(this.getApiKey());
+        return [
+            `https://api.steambot.info/v1/${apiKey}/inventory/${steamID}/${appID}/${contextID}`,
+            { count: 5000, language: 'en' }
+        ];
+    }
+
+    protected normalizeResponse(data: unknown): unknown {
+        const response = data as UnknownDictionaryKnownValues;
+        if (response?.success === true && response.data && typeof response.data === 'object') {
+            return { ...(response.data as UnknownDictionaryKnownValues), success: 1 };
+        }
+        return data;
+    }
+}

--- a/src/classes/InventoryGetter.ts
+++ b/src/classes/InventoryGetter.ts
@@ -6,12 +6,18 @@ import ExpressLoad from './InventoryApis/ExpressLoad';
 import InventoryApi from './InventoryApis/InventoryApi';
 import SteamSupply from './InventoryApis/SteamSupply';
 import SteamApis from './InventoryApis/SteamApis';
+import SteamBotInfo from './InventoryApis/SteamBotInfo';
 
 export default class InventoryGetter {
     private readonly inventoryApis: InventoryApi[];
 
     constructor(private readonly bot: Bot) {
-        this.inventoryApis = [new SteamSupply(this.bot), new SteamApis(this.bot), new ExpressLoad(this.bot)];
+        this.inventoryApis = [
+            new SteamSupply(this.bot),
+            new SteamApis(this.bot),
+            new ExpressLoad(this.bot),
+            new SteamBotInfo(this.bot)
+        ];
     }
 
     getUserInventoryContents(

--- a/src/classes/Options.ts
+++ b/src/classes/Options.ts
@@ -526,6 +526,9 @@ export const DEFAULTS: JsonOptions = {
         },
         expressLoad: {
             enable: false
+        },
+        steamBotInfo: {
+            enable: false
         }
     },
 
@@ -1686,6 +1689,7 @@ interface InventoryApis {
     steamSupply?: OnlyEnable;
     steamApis?: OnlyEnable;
     expressLoad?: OnlyEnable;
+    steamBotInfo?: OnlyEnable;
 }
 
 // ------------ Discord Chat ---------------
@@ -2273,6 +2277,7 @@ export default interface Options extends JsonOptions {
     steamSupplyApiKey?: string;
     steamApisApiKey?: string;
     expressLoadApiKey?: string;
+    steamBotInfoApiKey?: string;
     journalTfEnable?: boolean;
     journalTfApiKey?: string;
 
@@ -2597,6 +2602,7 @@ export function loadOptions(options?: Options): Options {
         steamSupplyApiKey: getOption('steamsupplyApiKey', '', String, incomingOptions),
         steamApisApiKey: getOption('steamapisApiKey', '', String, incomingOptions),
         expressLoadApiKey: getOption('expressloadApiKey', '', String, incomingOptions),
+        steamBotInfoApiKey: getOption('steambotInfoApiKey', '', String, incomingOptions),
         journalTfEnable: getOption('journalTfEnable', false, jsonParseBoolean, incomingOptions),
         journalTfApiKey: getOption('journalTfApiKey', '', String, incomingOptions),
 

--- a/src/schemas/options-json/options.ts
+++ b/src/schemas/options-json/options.ts
@@ -1618,9 +1618,12 @@ export const optionsSchema: jsonschema.Schema = {
                 },
                 expressLoad: {
                     $ref: '#/definitions/only-enable'
+                },
+                steamBotInfo: {
+                    $ref: '#/definitions/only-enable'
                 }
             },
-            required: ['steamSupply', 'steamApis', 'expressLoad'],
+            required: ['steamSupply', 'steamApis', 'expressLoad', 'steamBotInfo'],
             additionalProperties: false
         },
         discordChat: {

--- a/template.ecosystem.json
+++ b/template.ecosystem.json
@@ -30,6 +30,7 @@
                 "STEAMSUPPLY_API_KEY": "",
                 "STEAMAPIS_API_KEY": "",
                 "EXPRESSLOAD_API_KEY": "",
+                "STEAMBOT_INFO_API_KEY": "",
                 "JOURNAL_TF_ENABLE": false,
                 "JOURNAL_TF_API_KEY": "",
 


### PR DESCRIPTION
## Summary

- add SteamBot.info as an optional inventory API provider
- support SteamBot.info pagination through `start_assetid`
- normalize its `{ success, data }` response into the existing shared inventory parser
- add `STEAMBOT_INFO_API_KEY` and `inventoryApis.steamBotInfo.enable` configuration

## Behavior

SteamBot.info is registered after SteamSupply, SteamApis, and ExpressLoad, preserving the existing provider priority. It is disabled by default and requires both an API key and the provider enable flag.

No credentials are included in this change.

## Validation

- `npm run build`
- targeted ESLint for changed TypeScript files
- Prettier check for changed files
- Options Jest suite (8 tests)
- response normalization and pagination smoke test

